### PR TITLE
Document clickable badge recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ If you choose to publish, the workflow needs `contents: write`. Without that
 permission, the action will skip branch publication and emit a warning instead
 of failing unexpectedly.
 
+When you embed a badge in a README, it is usually better to make the image
+clickable instead of leaving it as a bare image. A raw SVG link only opens the
+image itself, which is rarely the most useful destination for a reader. In
+practice, many repositories will get a better result by linking the badge to a
+GitHub code search for the underlying marker text. That search is not expected
+to match `gh-counter` perfectly, because repository search may use broader file
+scope or simpler terms than the configured matcher, but it often gives readers
+a much more useful starting point than a full-screen image.
+
+```md
+[![TODOs](https://raw.githubusercontent.com/<owner>/<repo>/badge-assets/badges/todo.svg)](https://github.com/<owner>/<repo>/search?q=TODO&type=code)
+```
+
 ## How matching works
 
 Matching is line-based. A line counts at most once per counter, even when

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,6 +107,14 @@ machine-readable data. Users who only care about README badges can ignore the
 JSON files, while teams that want to build dashboards or secondary tooling can
 consume them directly.
 
+In many repositories, the most useful README badge is a linked badge rather
+than a standalone image. The generated SVG can stay in the publish branch, while
+the surrounding Markdown link points to a GitHub code search that approximates
+the counter's matcher. This is intentionally only a recommendation. Search
+queries are repository-specific, and they often use a looser approximation than
+the exact `gh-counter` matcher because GitHub code search and `gh-counter`
+matcher semantics are not identical.
+
 ## Example configuration
 
 ```yaml


### PR DESCRIPTION
## Summary

Document a practical recommendation for published gh-counter badges.
The README and configuration guide now explain that linked badges are usually more useful than bare images, and that GitHub code search is often a good destination even when it only approximates the matcher.
