### PR TITLE
Dogfood gh-counter in this repository

### DIFF
--- a/.github/gh-counter.yml
+++ b/.github/gh-counter.yml
@@ -1,5 +1,6 @@
 version: 1
 publish:
+  enabled: true
   branch: gh-counter-assets
 comment:
   key: self-check
@@ -16,10 +17,10 @@ counters:
     badge:
       label: TODOs
   - id: type-ignore
-    label: 'type: ignore'
+    label: '@ts-ignore'
     matchers:
       - files: ['src/**/*.ts']
         type: contains
         pattern: '@ts-ignore'
     badge:
-      label: 'type: ignore'
+      label: '@ts-ignore'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # gh-counter
 
+[![TODOs](https://raw.githubusercontent.com/kitsuyui/gh-counter/gh-counter-assets/badges/todo.svg)](https://github.com/kitsuyui/gh-counter/search?q=TODO&type=code)
+[![@ts-ignore](https://raw.githubusercontent.com/kitsuyui/gh-counter/gh-counter-assets/badges/type-ignore.svg)](https://github.com/kitsuyui/gh-counter/search?q=%22%40ts-ignore%22+path%3Asrc&type=code)
+
 `gh-counter` is a GitHub Action for counting configurable code markers in pull
 requests and on the default branch. It is meant for teams that want one small
 tool for debt counters such as `TODO`, `FIXME`, `@ts-ignore`, or
@@ -13,6 +16,9 @@ stable badge URLs, you can turn on publish-branch output and let the action
 write generated JSON and SVG files to a dedicated branch. That publish step is
 not enabled by default, because writing to another branch is more invasive than
 most users expect from a first-time setup.
+
+This repository uses `gh-counter` to track its own `TODO` and `@ts-ignore`
+markers and publishes the badges above from `gh-counter-assets`.
 
 ## Why the defaults look like this
 


### PR DESCRIPTION
## Summary

Use `gh-counter` in the `gh-counter` repository itself.
This enables publish-branch output for the existing self-check configuration and exposes the resulting badges in the README.
