### PR TITLE
Clarify README and configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,52 +4,21 @@
 [![@ts-ignore](https://raw.githubusercontent.com/kitsuyui/gh-counter/gh-counter-assets/badges/type-ignore.svg)](https://github.com/kitsuyui/gh-counter/search?q=%22%40ts-ignore%22+path%3Asrc&type=code)
 
 `gh-counter` is a GitHub Action for counting configurable code markers in pull
-requests and on the default branch. It is meant for teams that want one small
-tool for debt counters such as `TODO`, `FIXME`, `@ts-ignore`, or
-`# type: ignore`, while still being flexible enough to define their own
-patterns and badge labels.
+requests and on the default branch. It is designed for repositories that want a
+small, reusable way to track signals such as `TODO`, `FIXME`, `@ts-ignore`, or
+`# type: ignore`, while keeping setup simple enough for first-time adoption.
 
-The action is designed to be useful before you customize it heavily. If you run
-it on a pull request, it compares the current branch with the merge base and
-updates one managed comment in place. If you later decide that you also want
-stable badge URLs, you can turn on publish-branch output and let the action
-write generated JSON and SVG files to a dedicated branch. That publish step is
-not enabled by default, because writing to another branch is more invasive than
-most users expect from a first-time setup.
+On pull requests, it compares the head branch with the merge base and updates
+one managed comment in place. On pushes to the default branch, it can also
+publish JSON and SVG badge assets to a dedicated branch. This repository uses
+`gh-counter` to track its own `TODO` and `@ts-ignore` markers and publishes the
+badges above from `gh-counter-assets`.
 
-This repository uses `gh-counter` to track its own `TODO` and `@ts-ignore`
-markers and publishes the badges above from `gh-counter-assets`.
+## Quick start
 
-## Why the defaults look like this
-
-The default behavior is intentionally conservative. Pull request comments are
-enabled by default because they are the main value of the action and require
-only `pull-requests: write`. Publishing badges is disabled by default because it
-requires `contents: write`, creates or overwrites a dedicated branch, and is not
-needed to get useful signal from the action. The default branch is resolved from
-the repository metadata so that most users do not need to configure `main`,
-`master`, or a custom default branch explicitly. Counter labels default to the
-counter id so that a minimal configuration stays readable without repetition.
-
-Another important default is that pull requests only comment on counters whose
-matcher target files are actually touched by the pull request. This keeps the
-comment focused on the work being reviewed and avoids failing a pull request for
-an unrelated counter in an untouched area of the repository. On the default
-branch, by contrast, all configured counters are evaluated because the action is
-acting as a repository-level report rather than a review-time hint.
-
-There is one deliberate exception for first-time adoption. If a pull request
-adds `.github/gh-counter.yml` or adds a new workflow that uses `gh-counter`,
-but does not yet touch any matcher target files, the action posts a short
-bootstrap comment instead of staying silent. That gives maintainers a visible
-confirmation that the action is wired correctly without making ordinary
-unrelated pull requests noisy later.
-
-## Basic usage
-
-In the simplest setup, you check out the repository with full history, run the
-action, and give it a token that can write pull request comments. A repository
-that only wants PR comments does not need to enable branch publishing at all.
+The smallest useful setup is a pull-request comment workflow plus a config
+file. This keeps permissions narrow and avoids writing to extra branches until
+you actually want badges.
 
 ```yaml
 name: gh-counter
@@ -75,8 +44,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-The action looks for `.github/gh-counter.yml` by default. A minimal
-configuration only needs counters and matchers.
+The action reads `.github/gh-counter.yml` by default. A minimal configuration
+only needs counters and matchers.
 
 ```yaml
 version: 1
@@ -90,10 +59,92 @@ counters:
 ```
 
 With that setup, pull requests get one managed comment that compares the current
-count to the merge base. The comment is updated in place through an HTML marker,
-so reruns do not spam the thread with duplicates. If the pull request is only
-introducing `gh-counter` itself, the managed comment falls back to a short
-bootstrap message until a later pull request touches relevant matcher targets.
+count to the merge base. Reruns update the same comment instead of adding a new
+one.
+
+## Inputs
+
+The action itself has a small set of inputs. Most behavior lives in
+`.github/gh-counter.yml`, which keeps workflows short and makes repository-level
+policy easier to review.
+
+| Input | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `github-token` | Yes | none | Used for PR comments and publish-branch writes |
+| `config-path` | No | `.github/gh-counter.yml` | Path to the YAML or JSON config file |
+| `default-branch` | No | repository default branch | Overrides config and repository metadata |
+| `publish-branch` | No | value from config, else `gh-counter` | Overrides the publish branch name |
+| `comment-key` | No | value from config, else `default` | Overrides the HTML marker key |
+| `output-dir` | No | `.gh-counter` | Directory for generated JSON and SVG files |
+
+## Configuration at a glance
+
+The configuration file has a few required fields and many optional ones. The
+defaults are intentionally conservative: PR comments are on by default,
+publishing is off by default, and labels fall back to counter ids.
+
+### Top-level fields
+
+| Field | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `version` | No | none | Recommended to set to `1` |
+| `default_branch` | No | repository default branch | Usually not needed |
+| `comment.enabled` | No | `true` | Disables PR comment handling when set to `false` |
+| `comment.key` | No | `default` | Use a unique key if the repo runs multiple `gh-counter` jobs |
+| `comment.template` | No | built-in Mustache template | Customizes the PR comment body |
+| `publish.enabled` | No | `false` | Enables publish-branch updates for JSON and badges |
+| `publish.branch` | No | `gh-counter` | Branch used for published assets |
+| `publish.directory` | No | `.` | Root directory inside the publish branch |
+| `publish.summary_filename` | No | `summary.json` | Summary JSON file name |
+| `publish.badges_directory` | No | `badges` | Directory for generated SVG badges |
+| `publish.counters_directory` | No | `counters` | Directory for per-counter JSON files |
+| `counters` | Yes | none | At least one counter is required |
+
+### Counter fields
+
+| Field | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `counters[].id` | Yes | none | Stable identifier used in outputs and published file names |
+| `counters[].label` | No | `id` | Display label in comments and badges |
+| `counters[].matchers` | Yes | none | At least one matcher is required |
+| `counters[].limit.max` | No | none | Absolute threshold |
+| `counters[].limit.fail` | No | `false` | Fails the workflow when the limit is exceeded |
+| `counters[].ratchet.no_increase` | No | none | Prevents regressions relative to the baseline |
+| `counters[].ratchet.target` | No | none | Long-term threshold |
+| `counters[].ratchet.fail` | No | `false` | Fails the workflow on ratchet violations |
+| `counters[].badge.label` | No | counter label | Label shown on the generated badge |
+| `counters[].badge.colors.ok` | No | built-in color | Badge color below warning threshold |
+| `counters[].badge.colors.warn` | No | built-in color | Badge color at warning level |
+| `counters[].badge.colors.error` | No | built-in color | Badge color at error level |
+| `counters[].badge.thresholds.warn_above` | No | none | Switches badge to warning color above this count |
+| `counters[].badge.thresholds.error_above` | No | none | Switches badge to error color above this count |
+
+### Matcher fields
+
+| Field | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `matchers[].files` | Yes | none | Glob patterns to include |
+| `matchers[].exclude` | No | none | Extra globs to exclude |
+| `matchers[].type` | Yes | none | `contains` or `regex` |
+| `matchers[].pattern` | Yes | none | Literal string or regular expression |
+| `matchers[].case_sensitive` | No | `false` | Makes matching case-sensitive |
+
+## Why the defaults look like this
+
+The default behavior is intentionally conservative. Pull request comments are
+enabled by default because they are the main value of the action and require
+only `pull-requests: write`. Publishing badges is disabled by default because it
+requires `contents: write`, creates or overwrites a dedicated branch, and is not
+needed to get useful signal from a first setup. Counter labels default to the
+counter id so that a minimal configuration stays readable without repetition.
+
+Another important default is pull request relevance. `gh-counter` comments only
+on counters whose matcher target files are touched by the current diff, and it
+only fails a pull request for those relevant counters. This keeps the signal
+focused on the code under review. There is one exception for first-time
+adoption: if a pull request adds `.github/gh-counter.yml` or a new workflow that
+uses `gh-counter`, the action emits a short bootstrap comment even when no
+matcher target files are touched yet.
 
 ## When to enable publishing
 
@@ -124,12 +175,10 @@ of failing unexpectedly.
 
 When you embed a badge in a README, it is usually better to make the image
 clickable instead of leaving it as a bare image. A raw SVG link only opens the
-image itself, which is rarely the most useful destination for a reader. In
-practice, many repositories will get a better result by linking the badge to a
-GitHub code search for the underlying marker text. That search is not expected
-to match `gh-counter` perfectly, because repository search may use broader file
-scope or simpler terms than the configured matcher, but it often gives readers
-a much more useful starting point than a full-screen image.
+image itself. In practice, many repositories get a better result by linking the
+badge to a GitHub code search for the underlying marker text. That search is
+only an approximation of the matcher, but it is often a more useful starting
+point than a full-screen image.
 
 ```md
 [![TODOs](https://raw.githubusercontent.com/<owner>/<repo>/badge-assets/badges/todo.svg)](https://github.com/<owner>/<repo>/search?q=TODO&type=code)
@@ -142,9 +191,7 @@ multiple matchers on the same counter would match it. This is deliberate: a
 line such as `// FIXME: TODO because ...` should count as one debt instance for
 that counter, not two. The current implementation supports `contains` and
 `regex` matchers, and each matcher combines file globs with a single line
-pattern. Counters can have multiple matchers, which makes it practical to group
-related debt markers under one label without forcing one giant regular
-expression.
+pattern.
 
 ## Limits, ratchets, and failure behavior
 
@@ -153,10 +200,7 @@ maximum. A ratchet is directional: `no_increase` prevents a counter from going
 up relative to the baseline, while `target` expresses a longer-term threshold
 that the counter should eventually stay under. Each rule has its own `fail`
 switch so that teams can begin by observing a metric before they start enforcing
-it. On pull requests, only counters that are relevant to the current diff are
-allowed to fail the workflow. On default-branch pushes, all counters are
-evaluated because the baseline is the previously published summary or, if
-publishing is disabled, the run is informational only.
+it.
 
 ## Outputs and artifacts
 
@@ -168,9 +212,9 @@ failing violations, and the publish branch through action outputs.
 
 ## Documentation
 
-The README is intentionally focused on first-time adoption. The full
-configuration reference, field semantics, and publishing details live in
-[docs/configuration.md](docs/configuration.md).
+The README is intentionally focused on adoption and day-one configuration. The
+full configuration reference, field semantics, template details, and publishing
+layout live in [docs/configuration.md](docs/configuration.md).
 
 ## Marketplace and release notes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,61 @@
 # Configuration Reference
 
 `gh-counter` is configured through a YAML or JSON file, by default
-`.github/gh-counter.yml`. The configuration is intentionally split into three
-levels. Repository-level behavior such as publishing and comment handling lives
-at the top. Counter-level behavior defines what you are measuring. Matcher-level
-behavior defines how files and lines are selected.
+`.github/gh-counter.yml`. The configuration has three layers. Top-level fields
+control repository-wide behavior such as comments and publishing. Counter fields
+describe what you want to measure. Matcher fields describe how files and lines
+are selected.
+
+## Field summary
+
+The tables below are meant to answer the first questions quickly: what is
+required, what is optional, and what happens if you omit a field.
+
+### Top-level fields
+
+| Field | Required | Default | Meaning |
+| --- | --- | --- | --- |
+| `version` | No | none | Schema version. `1` is the current value |
+| `default_branch` | No | repository default branch | Baseline branch for default-branch pushes |
+| `comment.enabled` | No | `true` | Enables or disables PR comments |
+| `comment.key` | No | `default` | Unique marker key for idempotent comments |
+| `comment.template` | No | built-in Mustache template | Custom PR comment body |
+| `publish.enabled` | No | `false` | Enables publish-branch writes |
+| `publish.branch` | No | `gh-counter` | Publish branch name |
+| `publish.directory` | No | `.` | Root directory within the publish branch |
+| `publish.summary_filename` | No | `summary.json` | Summary JSON file name |
+| `publish.badges_directory` | No | `badges` | Badge SVG directory |
+| `publish.counters_directory` | No | `counters` | Per-counter JSON directory |
+| `counters` | Yes | none | List of counters to evaluate |
+
+### Counter fields
+
+| Field | Required | Default | Meaning |
+| --- | --- | --- | --- |
+| `counters[].id` | Yes | none | Stable identifier used in outputs and file names |
+| `counters[].label` | No | `id` | Human-friendly label for comments and badges |
+| `counters[].matchers` | Yes | none | Matchers belonging to the counter |
+| `counters[].limit.max` | No | none | Absolute maximum |
+| `counters[].limit.fail` | No | `false` | Fails the workflow when over the limit |
+| `counters[].ratchet.no_increase` | No | none | Forbids regression relative to the baseline |
+| `counters[].ratchet.target` | No | none | Long-term target threshold |
+| `counters[].ratchet.fail` | No | `false` | Fails the workflow on ratchet violations |
+| `counters[].badge.label` | No | counter label | Badge label override |
+| `counters[].badge.colors.ok` | No | built-in color | Badge color below warning level |
+| `counters[].badge.colors.warn` | No | built-in color | Badge color at warning level |
+| `counters[].badge.colors.error` | No | built-in color | Badge color at error level |
+| `counters[].badge.thresholds.warn_above` | No | none | Warning threshold for badge color |
+| `counters[].badge.thresholds.error_above` | No | none | Error threshold for badge color |
+
+### Matcher fields
+
+| Field | Required | Default | Meaning |
+| --- | --- | --- | --- |
+| `matchers[].files` | Yes | none | Include globs |
+| `matchers[].exclude` | No | none | Extra exclude globs |
+| `matchers[].type` | Yes | none | `contains` or `regex` |
+| `matchers[].pattern` | Yes | none | Literal string or regular expression |
+| `matchers[].case_sensitive` | No | `false` | Enables case-sensitive matching |
 
 ## Top-level behavior
 
@@ -25,11 +76,15 @@ Templates are written in Mustache. The built-in template is intentionally plain
 and readable, so most users should start there and customize only when they
 have a clear reporting need.
 
+The template receives `marker`, `bootstrap_message`, and `counters`. Each
+rendered counter includes the normalized summary fields plus `hasBase`,
+`has_violations`, `delta_label`, and `violation_messages`.
+
 The `publish` section controls branch publication. Publishing is disabled by
 default. This is the safest default because it avoids writing to repository
 branches until a user explicitly decides they need stable JSON or badge output.
-When enabled, the default branch name is `gh-counter`, which is short, specific,
-and unlikely to conflict with a human-maintained branch.
+When enabled, the default branch name is `gh-counter`, which is short,
+specific, and unlikely to conflict with a human-maintained branch.
 
 ## Counter definitions
 
@@ -124,6 +179,16 @@ publish:
   branch: badge-assets
 comment:
   key: engineering-metrics
+  template: |
+    {{{marker}}}
+    ## Engineering metrics
+
+    {{#counters}}
+    - {{label}}: {{current}}{{#hasBase}} (base: {{base}}, delta: {{delta_label}}){{/hasBase}}
+    {{/counters}}
+
+    ---
+    Reported by [gh-counter](https://github.com/kitsuyui/gh-counter)
 counters:
   - id: todo
     label: TODOs


### PR DESCRIPTION
## Summary
- reorganize the README around quick start, inputs, and config overview
- add required/optional/default tables for action inputs and configuration fields
- update the configuration example to show `comment.template` explicitly

## Testing
- pnpm test
