### PR TITLE
fix: ignore temp workspace files in Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -37,6 +37,7 @@
       "!**/node_modules",
       "!**/dist",
       "!**/coverage",
+      "!.tmp",
       "!**/*.md",
       "!**/pnpm-lock.yaml"
     ]


### PR DESCRIPTION
## Summary
- exclude the local .tmp workspace from Biome checks
- keep generated temp files from polluting the local lint baseline

## Testing
- pnpm lint
- pnpm test
- pnpm build
