### PR TITLE
Add gh-build-size reporting for action artifacts

### DIFF
--- a/.github/gh-build-size.yml
+++ b/.github/gh-build-size.yml
@@ -1,0 +1,25 @@
+version: 1
+publish:
+  enabled: true
+  branch: gh-build-size-assets
+comment:
+  key: action-build-size
+targets:
+  - id: total
+    label: Total action artifacts
+    files:
+      - dist/**
+    compressions: [raw, gzip, brotli]
+    badge:
+      compression: gzip
+      label: action artifacts (gzip)
+  - id: runtime
+    label: Runtime bundle
+    files:
+      - dist/**/*.mjs
+    compressions: [raw, gzip, brotli]
+  - id: sourcemaps
+    label: Source maps
+    files:
+      - dist/**/*.map
+    compressions: [raw, gzip, brotli]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   test:
@@ -13,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -29,3 +34,8 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Measure build size
+        uses: kitsuyui/gh-build-size@v0.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ badge assets to a dedicated branch for repository-wide reporting. This
 repository uses `gh-counter` to track its own `TODO`, `@ts-ignore`, and
 symbol-heavy `<code>` markers and publishes the badges above from
 `gh-counter-assets`.
+This repository also tracks its built action artifact size with
+[`gh-build-size`](https://github.com/kitsuyui/gh-build-size).
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

- add `gh-build-size` configuration for the committed action `dist/` outputs
- run `gh-build-size@v0.1.2` after the build step in CI
- mention build size tracking in the README

## Verification

- `git diff --check`
