### PR TITLE
Use reusable maintenance workflows

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -10,6 +10,4 @@ permissions:
 
 jobs:
   update-gitignore:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: gitignore-in/gh-action@98ab8a7225c88b81167bfef156dbad83c554aaf4
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -8,10 +8,4 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Check spelling
-        uses: crate-ci/typos@master
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main


### PR DESCRIPTION
## Summary
- Replace direct maintenance action invocations with reusable workflows from `kitsuyui/gh-actions-workflows`.
- Keep repository-specific triggers and permissions in the caller workflows.
- Split embedded spellcheck steps into a reusable spellcheck job where needed.

## Verification
- Parsed the changed workflow YAML files.
- Ran `actionlint` on the changed workflow files.
