### PR TITLE
Pin octocov workflow actions

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -15,9 +15,9 @@ jobs:
   octocov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 
@@ -34,7 +34,7 @@ jobs:
         run: bun run build
 
       - name: Report coverage with octocov
-        uses: k1LoW/octocov-action@v1
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config: .octocov.yml


### PR DESCRIPTION
## Summary
- Pin the octocov workflow GitHub Actions to immutable commit SHAs.
- Keep the original major-version tags as comments for update readability.

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/octocov.yml")'\n- actionlint .github/workflows/octocov.yml\n- bun install --frozen-lockfile\n- bun run lint\n- bun run test\n- bun run build