### PR TITLE
Pin gitignore workflow ref

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc


### PR DESCRIPTION
## Summary

- Pin the reusable `gitignore-in` workflow call to the current full commit SHA of `kitsuyui/gh-actions-workflows`
- Keep the existing workflow permissions and schedule unchanged

## Validation

- `git diff --check`
- `actionlint .github/workflows/gitignore-in.yml`
- Verified the reusable workflow file exists at the pinned commit via the GitHub API
