### PR TITLE
Clarify output scope descriptions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,9 +33,9 @@ outputs:
   summary-json:
     description: 'The generated summary JSON'
   violation-count:
-    description: 'Number of counters with failing conditions'
+    description: 'Number of counters with failing conditions in the current event scope (PRs only evaluate relevant counters)'
   has-violations:
-    description: 'Whether any configured failing condition was violated'
+    description: 'Whether any counter violated a failing condition in the current event scope (PRs only evaluate relevant counters)'
   publish-branch:
     description: 'The publish branch used for generated assets'
 


### PR DESCRIPTION
Summary:
- Clarify that `violation-count` and `has-violations` reflect the current event scope.
- Note in the action metadata that pull request runs only evaluate relevant counters.

Validation:
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run check:dist`
- `typos .`