### PR TITLE
Add SECURITY.md, CodeQL workflow, and reduce test token permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: codeql
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3
+        with:
+          languages: javascript-typescript
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub Issue to report a security vulnerability.
+
+Use [GitHub's private vulnerability reporting](https://github.com/kitsuyui/gh-counter/security/advisories/new) to submit a report. This keeps the details confidential until a fix is ready.
+
+Include the following in your report:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a minimal proof-of-concept
+- Any relevant version information
+
+You will receive a response as soon as possible. If the vulnerability is confirmed, a fix will be prepared and a public advisory will be published after the fix is released.


### PR DESCRIPTION
## Summary

Three security improvements to the repository's posture as a public GitHub Action:

- **Reduce test workflow token permissions**: Remove unnecessary `contents: write` from `test.yml`. The workflow only reads source and posts PR comments, so `contents: read` is sufficient.
- **Add SECURITY.md**: Document the private vulnerability reporting path via [GitHub Security Advisories](https://github.com/kitsuyui/gh-counter/security/advisories/new), guiding reporters away from public issues before a fix is ready.
- **Add CodeQL workflow**: Run GitHub's static analysis on every PR, push to main, and weekly to catch JavaScript/TypeScript security vulnerabilities early. Action refs are SHA-pinned to match existing workflow conventions.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/test.yml` | `contents: write` → `contents: read` |
| `SECURITY.md` | New — vulnerability disclosure policy |
| `.github/workflows/codeql.yml` | New — CodeQL analysis for javascript-typescript |

## Not addressed in this PR

The following items require GitHub repository settings changes (admin action) and are not covered by this PR:

- `secret_scanning_validity_checks`: Enable via repository Security settings
- `secret_scanning_non_provider_patterns`: Enable via repository Security settings
- Branch protection on `main`: Configure via repository Branches settings

## Verification

- Lint: `bun run lint` — passes (27 files, 0 errors)
- Tests: `bun run test` — 37 tests pass
