### PR TITLE
Document that renamed files keep their old path relevant in the PR gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ one exception for first-time adoption: if a pull request adds
 emits a short bootstrap comment even when no matcher target files are touched
 yet.
 
+When a pull request renames a file, `gh-counter` treats both the old path and
+the new path as potentially relevant to the PR gate. If either path matches a
+counter's `files` glob, that counter is considered active for the PR, and the
+ratchet check applies through the old path as well as the new one. This means
+that a counter can remain commentable even after its tracked file has been
+renamed out of the counter's scope. Pull requests that consist purely of
+renames may still trigger counter checks if the pre-rename path matched a
+counter's file pattern.
+
 ## When to enable publishing
 
 Publishing is the part that turns `gh-counter` from a review tool into a badge


### PR DESCRIPTION
## Summary

When a pull request renames a file, `gh-counter` evaluates both the old path
and the new path against each counter's `files` glob. If either path matches,
the counter becomes active for the PR gate and the ratchet check applies
through the old path as well as the new one.

This behavior is codified in the test suite (`changedFilesForMatcher`, line 51
of `src/git.spec.ts`) but was not described in the user-facing docs. Without
this explanation, a maintainer can reasonably assume that only the current
(post-rename) path matters, which leads to surprise when a pure rename PR
still triggers counter checks.

## Changes

- `README.md`: Added a paragraph to the PR gate section explaining that
  renamed files keep their pre-rename path relevant to the PR gate.

## Test plan

- [ ] Existing tests pass (`bun run test` — 58 tests, all pass)
- [ ] No lint or format errors (`bun run lint`, `bun run format`)
- [ ] README renders correctly on GitHub
