### PR TITLE
docs: document action outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,20 @@ workflow can upload those files as artifacts or inspect them in later steps.
 The action also exposes the summary path, the full summary JSON, the number of
 failing violations, and the publish branch through action outputs.
 
+The step outputs are:
+
+| Output | Meaning |
+| --- | --- |
+| `summary-path` | Path to the generated summary JSON file. |
+| `summary-json` | Full generated summary JSON as a string. |
+| `violation-count` | Number of counters with failing conditions in the current event scope. |
+| `has-violations` | `true` when any counter violated a failing condition in the current event scope; otherwise `false`. |
+| `publish-branch` | Publish branch used for generated assets. |
+
+For example, a later step can branch on
+`${{ steps.counter.outputs.has-violations }}` or upload
+`${{ steps.counter.outputs.summary-path }}`.
+
 ## Documentation
 
 The README is intentionally focused on adoption and day-one configuration. The

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,23 @@ required, what is optional, and what happens if you omit a field.
 | `matchers[].pattern` | Yes | none | Literal string or regular expression |
 | `matchers[].case_sensitive` | No | `false` | Enables case-sensitive matching |
 
+## Action outputs
+
+The action exposes named step outputs so downstream workflow steps can inspect
+the generated summary, gate on violations, or publish artifacts.
+
+| Output | Meaning |
+| --- | --- |
+| `summary-path` | Path to the generated summary JSON file. |
+| `summary-json` | Full generated summary JSON as a string. |
+| `violation-count` | Number of counters with failing conditions in the current event scope. |
+| `has-violations` | `true` when any counter violated a failing condition in the current event scope; otherwise `false`. |
+| `publish-branch` | Publish branch used for generated assets. |
+
+For example, a workflow can branch on
+`${{ steps.counter.outputs.has-violations }}` or upload
+`${{ steps.counter.outputs.summary-path }}` after the action runs.
+
 ## Top-level behavior
 
 The `version` field exists so that future schema changes can evolve without


### PR DESCRIPTION
## Summary
- Add step output reference tables for the GitHub Action.
- Document how downstream workflow steps can use `has-violations` and `summary-path`.

## Validation
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run check:dist`
- `actionlint -color`
- `typos`
- `git diff --check`
- `bunx madge --extensions ts --circular src`
