### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,21 @@ means `action.yml` stays at the repository root and `dist/` is committed for the
 release tag that users reference. Marketplace publication may also require
 account-level setup on GitHub's side, including agreement and listing metadata.
 
+## Development
+
+Install [lefthook](https://github.com/evilmartians/lefthook) and run the following command once to set up local Git hooks:
+
+```sh
+lefthook install
+```
+
+The hooks mirror the same checks that CI runs:
+
+- **pre-commit**: runs `bun run lint` (Biome static analysis)
+- **pre-push**: runs `bun run lint` and `bun run test` (Biome + Vitest)
+
+CI still executes the full suite on every push and pull request — the hooks bring the same feedback earlier, before a push is made.
+
 ## License
 
 MIT

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: lint
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run lint
+
+pre-push:
+  jobs:
+    - name: lint
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run lint
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run test


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` to mirror CI checks locally via Git hooks
- Add a `## Development` section to `README.md` documenting hook setup
- CI workflows are kept completely unchanged

## What the hooks do

| Hook | Jobs |
| --- | --- |
| pre-commit | `bun run lint` (Biome static analysis) |
| pre-push | `bun run lint` + `bun run test` (Biome + Vitest) |

Each job clears `GIT_*` environment variables before running so nested or sibling repositories are not affected.

## Test plan

- [x] Verified `bun run lint` passes on current code
- [x] Verified `bun run test` passes on current code (64 tests, 9 suites)
- [x] `lefthook install` succeeded; pre-commit hook ran and passed on commit
- [x] pre-push hook ran and passed (lint + test) on push
- [ ] CI passes on this PR (no CI files modified)
