### PR TITLE
ci: add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Validate version format
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          set -eu
-          set -o pipefail
-          if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+[.][0-9]+[.][0-9]+$'; then
-            echo "::error::version must match vMAJOR.MINOR.PATCH, got: $VERSION"
-            exit 1
-          fi
+        run: bash scripts/validate-semver.sh "${{ inputs.version }}"
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
@@ -42,8 +34,4 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          set -eu
-          set -o pipefail
-          gh release create "$VERSION" --generate-notes
+        run: gh release create "${{ inputs.version }}" --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g. v0.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -eu
+          set -o pipefail
+          if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+[.][0-9]+[.][0-9]+$'; then
+            echo "::error::version must match vMAJOR.MINOR.PATCH, got: $VERSION"
+            exit 1
+          fi
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify dist is up to date
+        run: bun run check:dist
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -eu
+          set -o pipefail
+          gh release create "$VERSION" --generate-notes

--- a/scripts/validate-semver.sh
+++ b/scripts/validate-semver.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+VERSION="${1:?Usage: validate-semver.sh <version>}"
+if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+[.][0-9]+[.][0-9]+$'; then
+  echo "::error::version must match vMAJOR.MINOR.PATCH, got: $VERSION" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch`-triggered release workflow that automates the tag and GitHub Release creation steps currently done manually.

- **`scripts/validate-semver.sh`** — validates the version input against `vMAJOR.MINOR.PATCH` before any release steps run
- **`.github/workflows/release.yml`** — the release workflow itself:
  1. Validates the version tag format via `scripts/validate-semver.sh`
  2. Verifies `dist/` is current (`bun run check:dist`) so the published action always reflects the latest build
  3. Creates a GitHub Release with auto-generated notes (`gh release create --generate-notes`)

## Motivation

Releasing previously required manually creating a git tag, verifying the `dist/` contents, and publishing a GitHub Release. Each step being manual creates opportunities for partial or out-of-order releases (e.g., tagging before dist is rebuilt). The `dist.yml` CI already guards against stale builds on PRs, but nothing enforced this at release time.

## Verification

- Semver validation script is unit-testable via `bash scripts/validate-semver.sh v1.2.3` (should succeed) and `bash scripts/validate-semver.sh 1.2.3` (should fail with an error message).
- The `check:dist` step will fail the workflow if the committed `dist/` does not match a fresh build, preserving the existing safety guarantee.
- Action refs in the workflow are pinned to full SHAs.

## Trade-offs

- Releases still require a human to trigger via `workflow_dispatch`; fully automated semantic-release is intentionally out of scope here.
- `--generate-notes` uses GitHub's default commit-range notes; a custom CHANGELOG tool can be layered on later independently.
