### PR TITLE
ci: run dist check on tag pushes

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

Add a `push.tags` trigger to the `dist` workflow so that `bun run check:dist` runs whenever a version tag is pushed, even when the tag is created directly via `git tag` or the GitHub Releases UI instead of going through the `release` workflow.

## Motivation

`action.yml` references a committed `dist/index.mjs`, so the dist content at a tag directly determines what code runs for users of `uses: kitsuyui/gh-counter@<version>`. The `dist.yml` workflow currently guards dist freshness on pull requests and `main` pushes, but a tag created outside the PR flow (e.g. `git tag v1.6 && git push origin v1.6`) would never trigger the check.

With this change, any tag push matching `v*` will run `check:dist`. If the committed `dist/` is stale relative to the source, the workflow fails and the problem surfaces before the release is used.

## Changes

- `.github/workflows/dist.yml`: add `tags: ['v*']` under the existing `push` trigger

## Verification

- CI passes on this PR (biome lint, existing checks).
- The added trigger can be tested by pushing a test tag; the workflow should run and either pass or fail based on the current dist state.
