### PR TITLE
ci: add dependency review and build provenance attestation

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,17 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -30,6 +32,11 @@ jobs:
 
       - name: Verify dist is up to date
         run: bun run check:dist
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: 'dist/index.mjs'
 
       - name: Create release
         env:


### PR DESCRIPTION
## What

Add two supply-chain security controls that were missing:

1. **Dependency review** (`.github/workflows/dependency-review.yml`): runs `actions/dependency-review-action` on every PR to detect newly added npm dependencies with known CVEs before they merge into main. This is distinct from Dependabot security updates, which react only after a vulnerable dependency is already merged.

2. **Build provenance attestation** (`.github/workflows/release.yml`): adds `actions/attest-build-provenance` so that `dist/index.mjs` receives a SLSA provenance attestation on each release. Consumers can verify the artifact was produced from this repository's source via `gh attestation verify`.

## Why

`gh-counter` is distributed as a GitHub Action consumed by other repositories via `uses: kitsuyui/gh-counter@vX.Y`. That positions this repo as a supply-chain source. The committed `dist/index.mjs` binary had no attestation, and PR dependency additions bypassed CVE screening.

## Changes

| File | Change |
|---|---|
| `.github/workflows/dependency-review.yml` | New workflow; triggers on pull_request |
| `.github/workflows/release.yml` | Add `attest-build-provenance` step + `id-token: write` / `attestations: write` permissions |

## Verification

- Lint: `bun run lint` — clean
- Tests: 2 preexisting timeouts in `src/git.spec.ts` (unrelated to this change; reproducible on `main` before this PR)
