### PR TITLE
Keep scheduled gitignore updates non-blocking

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -10,4 +10,5 @@ permissions:
 
 jobs:
   update-gitignore:
+    continue-on-error: true
     uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc


### PR DESCRIPTION
## Summary

The scheduled gitignore update can still refresh its branch when repository settings prevent GitHub Actions from opening a pull request. Marking the reusable workflow job as non-blocking keeps that expected restriction from making the scheduled run fail.

## Verification

- `bun run lint`
- `bun run test` (70 tests)
- `bun run check:dist`
- `git diff --check origin/main...HEAD`
