### PR TITLE
Limit gh-counter workflow permissions on pull requests

### DIFF
--- a/.github/workflows/gh-counter.yml
+++ b/.github/workflows/gh-counter.yml
@@ -12,13 +12,42 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  gh-counter:
+  gh-counter-pr:
+    if: github.event_name == 'pull_request'
+    name: gh-counter
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - name: Run gh-counter
+        id: counter
+        uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload generated files
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: gh-counter-output
+          path: .gh-counter
+          include-hidden-files: true
+          retention-days: 30
+
+  gh-counter-push:
+    if: github.event_name == 'push'
+    name: gh-counter
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check out repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5


### PR DESCRIPTION
## Summary

- split the self-check workflow into pull_request and push jobs so pull requests only receive `contents: read` while push runs keep `contents: write` for asset publishing

- keep the visible check name as `gh-counter` across both event paths to avoid unnecessary required-check churn

## Verification
- bun run lint
- bun run test
- bun run build
