### PR TITLE
ci: verify CI status before manual release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
   contents: write
   id-token: write
   attestations: write
+  checks: read
 
 jobs:
   release:
@@ -19,6 +20,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Verify CI has passed for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/verify-ci-status.sh "${{ github.repository }}" "${{ github.sha }}"
 
       - name: Validate version format
         run: bash scripts/validate-semver.sh "${{ inputs.version }}"

--- a/scripts/verify-ci-status.sh
+++ b/scripts/verify-ci-status.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+REPO="${1:?Usage: verify-ci-status.sh <owner/repo> <sha>}"
+SHA="${2:?Usage: verify-ci-status.sh <owner/repo> <sha>}"
+
+conclusions=$(gh api "repos/${REPO}/commits/${SHA}/check-runs" --jq '.check_runs[] | select(.name=="test") | .conclusion')
+
+if [ -z "$conclusions" ]; then
+  echo "::error::No 'test' check run found for commit ${SHA}. Refusing to release a commit that has not cleared CI." >&2
+  exit 1
+fi
+
+for conclusion in $conclusions; do
+  if [ "$conclusion" != "success" ]; then
+    echo "::error::The 'test' check run for commit ${SHA} has not succeeded (conclusion: ${conclusion}). Refusing to release." >&2
+    exit 1
+  fi
+done
+
+echo "CI check 'test' passed for commit ${SHA}."


### PR DESCRIPTION
## Summary

- The `Release` workflow (`workflow_dispatch`) previously only validated the version string and confirmed `dist` was up to date. It did not check whether the commit being released had passed the repository's normal CI (`test` workflow).
- A manual release could therefore publish a revision that never cleared lint/test/build, weakening the release process as a quality boundary.
- Adds a `Verify CI has passed for this commit` step that queries the commit's `test` check-run via the GitHub API (`scripts/verify-ci-status.sh`) and fails the release job unless that check-run concluded with `success`.

## Behavior preserved / changed

- Observable capability before: any commit could be released via `workflow_dispatch` regardless of CI status.
- Capability preserved: manual `workflow_dispatch` release flow, semver validation, dist-freshness check, provenance attestation, and `gh release create` all remain unchanged.
- Capability added: the release job now exits non-zero (refusing to release) if the target commit has no `test` check-run or that check-run's conclusion is not `success`.

## Test plan

- `bun run lint` — passes (biome check, 27 files, no issues).
- `bun run test` — passes (9 files / 70 tests, vitest + coverage).
- Exercised `scripts/verify-ci-status.sh` directly against a mocked `gh` CLI covering all three primary paths:
  - `test` check-run concluded `success` → script exits 0.
  - `test` check-run concluded `failure` → script exits 1 with an `::error::` annotation.
  - no `test` check-run found for the commit → script exits 1 with an `::error::` annotation.